### PR TITLE
SETI-808: Ignore non-ASCII jobs in Jenkins

### DIFF
--- a/src/main/java/hudson/plugins/gearman/GearmanProject.java
+++ b/src/main/java/hudson/plugins/gearman/GearmanProject.java
@@ -8,6 +8,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.nio.charset.Charset;
 
 /**
  * This class acts as facade for manipulation with Jenkins items in Gearman plugin. It allows to use
@@ -28,6 +29,16 @@ public abstract class GearmanProject<JobT extends Job, RunT extends Run> {
      */
     static boolean isSupported(Object object){
         return object instanceof WorkflowJob || object instanceof AbstractProject;
+    }
+
+    /**
+     * Does job have ASCII-only name
+     *
+     * @param project to test
+     * @return true if job name is ASCII-only string, otherwise false
+     */
+    static boolean hasAsciiName(GearmanProject project){
+        return Charset.forName("US-ASCII").newEncoder().canEncode(project.getJob().getName());
     }
 
     /**
@@ -56,6 +67,7 @@ public abstract class GearmanProject<JobT extends Job, RunT extends Run> {
                 .stream()
                 .filter( (Job job) -> isSupported(job))
                 .map( (Job job) -> projectFactory(job) )
+                .filter( (GearmanProject project) -> hasAsciiName(project))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Python implementation of gearman server breaks down when trying to
register a non-ASCII job from workers. This is an upstream bug and
since we do not have our own fork of gear server, the easiest
solution is to ignore jobs with non-ASCII names.

These are already forbidden in zuul layout, which is the only
source jobs handed to gearman. Effectively, this is just a
security measure to prevent gearman server from failing in case
somebody accidentaly manually (not through gooddata/ci-infra repo)
adds a non-ASCII job to Jenkins.