### PR TITLE
SETI-618: Provide option for disabling custom gearman job scheduling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,13 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <repositories>
+        <repository>
+            <id>jenkins</id>
+            <url>http://repo.jenkins-ci.org/releases/</url>
+        </repository>
+    </repositories>
+
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>

--- a/src/main/java/hudson/plugins/gearman/Constants.java
+++ b/src/main/java/hudson/plugins/gearman/Constants.java
@@ -28,6 +28,7 @@ public interface Constants {
     public static final boolean GEARMAN_DEFAULT_ENABLE_PLUGIN = false;
     public static final String GEARMAN_DEFAULT_TCP_HOST = "127.0.0.1";
     public static final int GEARMAN_DEFAULT_TCP_PORT = 4730;
+    public static final boolean GEARMAN_DEFAULT_ENABLE_SCHEDULING = false;
 
     public static final String PLUGIN_LOGGER_NAME = "hudson.plugins.gearman.logger";
 }

--- a/src/main/java/hudson/plugins/gearman/GearmanPluginConfig.java
+++ b/src/main/java/hudson/plugins/gearman/GearmanPluginConfig.java
@@ -51,6 +51,7 @@ public class GearmanPluginConfig extends GlobalConfiguration {
     private boolean enablePlugin; // config to enable and disable plugin
     private String host; // gearman server host
     private int port; // gearman server port
+    private boolean enableScheduling; // disable custom Gearman scheduling
 
     /**
      * Constructor.
@@ -97,6 +98,7 @@ public class GearmanPluginConfig extends GlobalConfiguration {
         enablePlugin = json.getBoolean("enablePlugin");
         host = json.getString("host");
         port = json.getInt("port");
+        enableScheduling = json.getBoolean("enableScheduling");
 
         if (!enablePlugin && prevEnablePlugin) {  // gearman-plugin goes from ON to OFF state
             GearmanProxy.getInstance().stopAll();
@@ -165,6 +167,10 @@ public class GearmanPluginConfig extends GlobalConfiguration {
         } else {
             return port;
         }
+    }
+
+    public boolean enableScheduling() {
+        return Objects.firstNonNull(enableScheduling, Constants.GEARMAN_DEFAULT_ENABLE_SCHEDULING);
     }
 
     /*

--- a/src/main/java/hudson/plugins/gearman/NodeAvailabilityMonitor.java
+++ b/src/main/java/hudson/plugins/gearman/NodeAvailabilityMonitor.java
@@ -135,7 +135,8 @@ public class NodeAvailabilityMonitor implements AvailabilityMonitor {
             logger.debug("AvailabilityMonitor canTake request for UUID " +
                          param.getUuid() + " expecting " + expectedUUID);
 
-            if (expectedUUID.equalsIgnoreCase(param.getUuid())) {
+            if (expectedUUID != null &&
+                expectedUUID.equalsIgnoreCase(param.getUuid())) {
                 return true;
             }
         }

--- a/src/main/java/hudson/plugins/gearman/QueueTaskDispatcherImpl.java
+++ b/src/main/java/hudson/plugins/gearman/QueueTaskDispatcherImpl.java
@@ -41,7 +41,9 @@ public class QueueTaskDispatcherImpl extends QueueTaskDispatcher {
     public CauseOfBlockage canTake(Node node,
                                    Queue.BuildableItem item) {
         // update only when gearman-plugin is enabled
-        if (!GearmanPluginConfig.get().enablePlugin()) {
+        // and custom gearman scheduling is enabled
+        if (!GearmanPluginConfig.get().enablePlugin() ||
+            !GearmanPluginConfig.get().enableScheduling()) {
             return null;
         }
 

--- a/src/main/java/hudson/plugins/gearman/StartJobWorker.java
+++ b/src/main/java/hudson/plugins/gearman/StartJobWorker.java
@@ -148,27 +148,46 @@ public class StartJobWorker extends AbstractGearmanFunction {
         }
 
         /*
-         * make this node build this project with unique id and build params from the client
+         * build this project with unique id and build params from the client
          */
-        String runNodeName = GearmanPluginUtil.getRealName(computer);
-
-        // create action to run on a specified computer
-        Action runNode = new NodeAssignmentAction(runNodeName);
-        // create action for parameters
-        Action params = new NodeParametersAction(buildParams, decodedUniqueId);
-        Action [] actions = {runNode, params};
 
         AvailabilityMonitor availability =
-            GearmanProxy.getInstance().getAvailabilityMonitor(computer);
+                GearmanProxy.getInstance().getAvailabilityMonitor(computer);
 
         availability.expectUUID(decodedUniqueId);
 
-        // schedule jenkins to build project
-        logger.info("---- Worker " + this.worker + " scheduling " +
-                    project.getJob().getName()+" build #" +
-                    project.getJob().getNextBuildNumber()+" on " + runNodeName
-                    + " with UUID " + decodedUniqueId + " and build params " + buildParams);
-        QueueTaskFuture<?> future = project.scheduleBuild2(0, new Cause.UserIdCause(), actions);
+        // create action for parameters
+        Action params = new NodeParametersAction(buildParams, decodedUniqueId);
+
+        QueueTaskFuture<?> future;
+
+        // build on a specific node tied to the executor if custom gearman-plugin
+        // scheduling is enabled
+        if(GearmanPluginConfig.get().enableScheduling()) {
+            String runNodeName = GearmanPluginUtil.getRealName(computer);
+
+            // create action to run on a specified computer
+            Action runNode = new NodeAssignmentAction(runNodeName);
+
+            Action [] actions = {runNode, params};
+
+            logger.info("---- Worker " + this.worker + " scheduling " +
+                        project.getJob().getName()+" build #" +
+                        project.getJob().getNextBuildNumber()+" on " + runNodeName
+                        + " with UUID " + decodedUniqueId + " and build params " + buildParams);
+            // schedule jenkins to build project
+            future = project.scheduleBuild2(0, new Cause.UserIdCause(), actions);
+        }
+        else {
+            Action [] actions = {params};
+
+            logger.info("---- Worker " + this.worker + " scheduling " +
+                        project.getJob().getName()+" build #" +
+                        project.getJob().getNextBuildNumber() +
+                        " with UUID " + decodedUniqueId + " and build params " + buildParams);
+            // schedule jenkins to build project
+            future = project.scheduleBuild2(0, new Cause.UserIdCause(), actions);
+        }
 
         // check build and pass results back to client
         String jobData;

--- a/src/main/resources/hudson/plugins/gearman/GearmanPluginConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/gearman/GearmanPluginConfig/config.jelly
@@ -14,5 +14,9 @@
       description="Select to enable Gearman plugin, Unselect to disable">
       <f:checkbox checked="${descriptor.enablePlugin()}"/>
     </f:entry>
+    <f:entry title="Enable custom Gearman scheduling" field="enableScheduling"
+      description="Let gearman-plugin decide where and when to launch jobs (disable if you're using throttling plugin)">
+      <f:checkbox checked="${descriptor.enableScheduling()}"/>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/gearman/GearmanPluginConfig/help-enableScheduling.html
+++ b/src/main/resources/hudson/plugins/gearman/GearmanPluginConfig/help-enableScheduling.html
@@ -1,0 +1,7 @@
+<div>
+    <p>
+        Select if you want Gearman to take control of job scheduling. Gearman will bypass global Jenkins queue and
+        launch jobs directly on specific executors. Useful in multiple Jenkins masters scenarios. Will cause harm when
+        used with throttling plugin.
+    </p>
+</div>


### PR DESCRIPTION
Main reason for this is to fix scheduling clashes between throttling plugin and gearman plugin.
More info in commit messages.