### PR TITLE
CONFIG: SETI-3633 Support Configuration as Code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,13 +27,13 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.2</version>
+        <version>3.55</version>
         <relativePath />
     </parent>
 
     <artifactId>gearman-plugin</artifactId>
     <packaging>hpi</packaging>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.3-SNAPSHOT</version>
 
     <name>Gearman Plugin</name>
     <description>Integrates Gearman application framework with Jenkins</description>
@@ -77,9 +77,10 @@
         <java.level>8</java.level>
         <jenkins.version>2.107.2</jenkins.version>
         <!-- define all plugin versions -->
+        <configuration-as-code.version>1.35</configuration-as-code.version>
         <gson.version>2.8.2</gson.version>
         <gearman.version>0.6</gearman.version>
-        <hamcrest.version>1.3</hamcrest.version>
+        <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>2.15.0</mockito.version>
         <powermock.version>2.0.0-beta.5</powermock.version>
         <objenesis.version>2.6</objenesis.version>
@@ -93,6 +94,18 @@
 
 
     <dependencies>
+        <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <version>${configuration-as-code.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
+            <version>${configuration-as-code.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
@@ -117,6 +130,12 @@
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
             <version>${jenkins-maven-plugin}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.maven.wagon</groupId>
+                    <artifactId>wagon-ftp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/hudson/plugins/gearman/ComputerListenerImpl.java
+++ b/src/main/java/hudson/plugins/gearman/ComputerListenerImpl.java
@@ -45,7 +45,7 @@ public class ComputerListenerImpl extends ComputerListener {
                 + " onConfigurationChange");
 
         // update functions only when gearman-plugin is enabled
-        if (!GearmanPluginConfig.get().enablePlugin()) {
+        if (!GearmanPluginConfig.get().isEnablePlugin()) {
             return;
         }
 
@@ -65,7 +65,7 @@ public class ComputerListenerImpl extends ComputerListener {
                 + " onOffline computer" + c);
 
         // update functions only when gearman-plugin is enabled
-        if (!GearmanPluginConfig.get().enablePlugin()) {
+        if (!GearmanPluginConfig.get().isEnablePlugin()) {
             return;
         }
 
@@ -83,7 +83,7 @@ public class ComputerListenerImpl extends ComputerListener {
                 + " onOnline computer " + c);
 
         // update functions only when gearman-plugin is enabled
-        if (!GearmanPluginConfig.get().enablePlugin()) {
+        if (!GearmanPluginConfig.get().isEnablePlugin()) {
             return;
         }
 
@@ -105,7 +105,7 @@ public class ComputerListenerImpl extends ComputerListener {
         logger.info("---- " + ComputerListenerImpl.class.getName() + ":"
                 + " onTemporarilyOffline computer " + c);
         // update functions only when gearman-plugin is enabled
-        if (!GearmanPluginConfig.get().enablePlugin()) {
+        if (!GearmanPluginConfig.get().isEnablePlugin()) {
             return;
         }
 
@@ -119,7 +119,7 @@ public class ComputerListenerImpl extends ComputerListener {
         logger.info("---- " + ComputerListenerImpl.class.getName() + ":"
                 + " onTemporarilyOnline computer " + c);
         // update functions only when gearman-plugin is enabled
-        if (!GearmanPluginConfig.get().enablePlugin()) {
+        if (!GearmanPluginConfig.get().isEnablePlugin()) {
             return;
         }
 

--- a/src/main/java/hudson/plugins/gearman/GearmanPluginConfig.java
+++ b/src/main/java/hudson/plugins/gearman/GearmanPluginConfig.java
@@ -17,6 +17,7 @@
  */
 package hudson.plugins.gearman;
 
+import hudson.BulkChange;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
@@ -32,6 +33,7 @@ import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -134,17 +136,41 @@ public class GearmanPluginConfig extends GlobalConfiguration {
 
         }
 
-        req.bindJSON(this, json);
-        save();
+        // Use of BulkChange allows avoiding repeated calls to save() to actually persist to disk only once fully configured
+        BulkChange bc = new BulkChange(this);
+        try {
+            req.bindJSON(this, json);
+            bc.commit();
+        } catch (IOException e) {
+            bc.abort();
+            throw new FormException("Failed to apply configuration", e, null);
+        }
         return true;
     }
 
+    @DataBoundSetter
+    public void setHost(String host) {
+        this.host = host;
+        save();
+    }
+
+    @DataBoundSetter
+    public void setPort(int port) {
+        this.port = port;
+        save();
+    }
+
+    @DataBoundSetter
+    public void setEnablePlugin(boolean enablePlugin) {
+        this.enablePlugin = enablePlugin;
+        save();
+    }
 
     /**
      * This method returns true if the global configuration says we should
      * enable the plugin.
      */
-    public boolean enablePlugin() {
+    public boolean isEnablePlugin() {
         return Objects.firstNonNull(enablePlugin, Constants.GEARMAN_DEFAULT_ENABLE_PLUGIN);
     }
 

--- a/src/main/java/hudson/plugins/gearman/ItemListenerImpl.java
+++ b/src/main/java/hudson/plugins/gearman/ItemListenerImpl.java
@@ -75,7 +75,7 @@ public class ItemListenerImpl extends ItemListener {
     // register gearman functions
     private void registerJobs() {
         // update functions only when gearman-plugin is enabled
-        if (!GearmanPluginConfig.get().enablePlugin()) {
+        if (!GearmanPluginConfig.get().isEnablePlugin()) {
             return;
         }
         GearmanProxy.getInstance().registerJobs();

--- a/src/main/java/hudson/plugins/gearman/QueueTaskDispatcherImpl.java
+++ b/src/main/java/hudson/plugins/gearman/QueueTaskDispatcherImpl.java
@@ -41,7 +41,7 @@ public class QueueTaskDispatcherImpl extends QueueTaskDispatcher {
     public CauseOfBlockage canTake(Node node,
                                    Queue.BuildableItem item) {
         // update only when gearman-plugin is enabled
-        if (!GearmanPluginConfig.get().enablePlugin()) {
+        if (!GearmanPluginConfig.get().isEnablePlugin()) {
             return null;
         }
 

--- a/src/main/java/hudson/plugins/gearman/RunListenerImpl.java
+++ b/src/main/java/hudson/plugins/gearman/RunListenerImpl.java
@@ -41,7 +41,7 @@ public class RunListenerImpl extends RunListener<Run> {
     @Override
     public void onFinalized(Run r) {
         // update only when gearman-plugin is enabled
-        if (!GearmanPluginConfig.get().enablePlugin()) {
+        if (!GearmanPluginConfig.get().isEnablePlugin()) {
             return;
         }
 

--- a/src/main/java/hudson/plugins/gearman/SaveableListenerImpl.java
+++ b/src/main/java/hudson/plugins/gearman/SaveableListenerImpl.java
@@ -46,7 +46,7 @@ public class SaveableListenerImpl extends SaveableListener {
     // also doesn't provide much detail on what has changed.
     public void onChange(Saveable o, XmlFile file) {
         // update functions only when gearman-plugin is enabled
-        if (!GearmanPluginConfig.get().enablePlugin()) {
+        if (!GearmanPluginConfig.get().isEnablePlugin()) {
             return;
         }
 

--- a/src/test/java/hudson/plugins/gearman/ConfigurationAsCodeTest.java
+++ b/src/test/java/hudson/plugins/gearman/ConfigurationAsCodeTest.java
@@ -1,0 +1,43 @@
+package hudson.plugins.gearman;
+
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.model.CNode;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static io.jenkins.plugins.casc.misc.Util.getUnclassifiedRoot;
+import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
+import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class ConfigurationAsCodeTest {
+
+    @ClassRule
+    @ConfiguredWithCode("configuration-as-code.yml")
+    public static JenkinsConfiguredWithCodeRule rule = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    public void shouldSupportConfigurationAsCode() throws Exception {
+        GearmanPluginConfig gpc = rule.jenkins.getDescriptorByType(GearmanPluginConfig.class);;
+
+        assertThat(gpc.getHost(), is("myhost.example"));
+        assertThat(gpc.getPort(), is(12345));
+        assertThat(gpc.isEnablePlugin(), is(true));
+    }
+
+    @Test
+    public void shouldSupportConfigurationAsCodeExport() throws Exception {
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        CNode gearmanAttribute = getUnclassifiedRoot(context).get("gearmanPluginConfig");
+
+        String exported = toYamlString(gearmanAttribute);
+        String expected = toStringFromYamlFile(this, "configuration-as-code-expected.yml");
+
+        assertThat(exported, is(expected));
+    }
+}

--- a/src/test/java/hudson/plugins/gearman/GearmanPluginConfigTest.java
+++ b/src/test/java/hudson/plugins/gearman/GearmanPluginConfigTest.java
@@ -69,6 +69,6 @@ public class GearmanPluginConfigTest {
     @Test
     public void testDefaultLaunchWorker() {
         assertEquals(Constants.GEARMAN_DEFAULT_ENABLE_PLUGIN,
-                gpc.enablePlugin());
+                gpc.isEnablePlugin());
     }
 }

--- a/src/test/resources/hudson/plugins/gearman/configuration-as-code-expected.yml
+++ b/src/test/resources/hudson/plugins/gearman/configuration-as-code-expected.yml
@@ -1,0 +1,3 @@
+enablePlugin: true
+host: "myhost.example"
+port: 12345

--- a/src/test/resources/hudson/plugins/gearman/configuration-as-code.yml
+++ b/src/test/resources/hudson/plugins/gearman/configuration-as-code.yml
@@ -1,0 +1,5 @@
+unclassified:
+    gearmanPluginConfig:
+        port: 12345
+        host: myhost.example
+        enablePlugin: true


### PR DESCRIPTION
- Configuration as Code relies on Describable and DataBound mechanism

- The getter and setter method should contain the name of the property
to be usable for configuration-as-code.

- Apparently, the boolean getter should start with either 'is' or 'has'
(eg. isSomething() getter), otherwise configuration-as-code can't detect
it.

Tested on https://jenkins-master-dev69.na.intgdc.com/configuration-as-code/viewExport